### PR TITLE
feat: automatic lazy loading + health check + support configuration with `vim.g`

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,9 @@ require('oil-git-status').setup({
 })
 ```
 
+You can also configure this plugin by setting `vim.g.oil_git_status`
+instead of calling `setup`.
+
 > [!NOTE]
 >
 > You do not need to call `setup` if you are happy with the

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ require("oil").setup({
     "stevearc/oil.nvim",
   },
 
-  config = true,
+  lazy = false, -- This plugin is already lazy.
 },
 ```
 
@@ -35,14 +35,6 @@ require("oil").setup({
 ```lua
 use {
   'refractalize/oil-git-status.nvim',
-
-  after = {
-    "oil.nvim",
-  },
-
-  config = function()
-    require("oil-git-status").setup()
-  end,
 }
 ```
 
@@ -53,6 +45,12 @@ require('oil-git-status').setup({
   show_ignored = true -- show files that match gitignore with !!
 })
 ```
+
+> [!NOTE]
+>
+> You do not need to call `setup` if you are happy with the
+> default config. This plugin will load automatically when
+> you open an oil buffer.
 
 ## Highlight Groups
 

--- a/ftplugin/oil.lua
+++ b/ftplugin/oil.lua
@@ -1,0 +1,34 @@
+local oil_git_status = require("oil-git-status")
+
+if not vim.g.oil_git_status_did_setup then
+  oil_git_status.validate_oil_config()
+  oil_git_status.set_highlights()
+  vim.g.oil_git_status_did_setup = true
+end
+
+local buffer = vim.api.nvim_get_current_buf()
+local current_status = nil
+
+if vim.b[buffer].oil_git_status_started then
+  return
+end
+
+vim.b[buffer].oil_git_status_started = true
+
+local augroup = vim.api.nvim_create_augroup("oil-git-status", {})
+
+vim.api.nvim_create_autocmd({ "BufReadPost", "BufWritePost" }, {
+  buffer = buffer,
+  callback = function()
+    oil_git_status.update_git_status(buffer)
+  end,
+  group = augroup,
+})
+
+vim.api.nvim_create_autocmd({ "InsertLeave", "TextChanged" }, {
+  buffer = buffer,
+  callback = function()
+    oil_git_status.refresh(buffer)
+  end,
+  group = augroup,
+})

--- a/lua/oil-git-status.lua
+++ b/lua/oil-git-status.lua
@@ -1,4 +1,3 @@
-local oil = require("oil")
 local namespace = vim.api.nvim_create_namespace("oil-git-status")
 local system = require("oil-git-status.system").system
 
@@ -82,7 +81,7 @@ local function add_status_extmarks(buffer, status)
 
   if status then
     for n = 1, vim.api.nvim_buf_line_count(buffer) do
-      local entry = oil.get_entry_on_line(buffer, n)
+      local entry = require("oil").get_entry_on_line(buffer, n)
       if entry then
         local name = entry.name
         local status_codes = status[name] or (current_config.show_ignored and { index = "!", working_tree = "!" })
@@ -184,45 +183,9 @@ local highlight_groups = generate_highlight_groups()
 --- @param config {show_ignored: boolean}
 local function setup(config)
   current_config = vim.tbl_extend("force", default_config, config or {})
+end
 
-  validate_oil_config()
-
-  vim.api.nvim_create_autocmd({ "FileType" }, {
-    pattern = { "oil" },
-
-    callback = function()
-      local buffer = vim.api.nvim_get_current_buf()
-      local current_status = nil
-
-      if vim.b[buffer].oil_git_status_started then
-        return
-      end
-
-      vim.b[buffer].oil_git_status_started = true
-
-      vim.api.nvim_create_autocmd({ "BufReadPost", "BufWritePost" }, {
-        buffer = buffer,
-
-        callback = function()
-          load_git_status(buffer, function(status)
-            current_status = status
-            add_status_extmarks(buffer, current_status)
-          end)
-        end,
-      })
-
-      vim.api.nvim_create_autocmd({ "InsertLeave", "TextChanged" }, {
-        buffer = buffer,
-
-        callback = function()
-          if current_status then
-            add_status_extmarks(buffer, current_status)
-          end
-        end,
-      })
-    end,
-  })
-
+local function set_highlights()
   for _, hl_group in ipairs(highlight_groups) do
     if hl_group.index then
       vim.api.nvim_set_hl(0, hl_group.hl_group, { link = "DiagnosticSignInfo", default = true })
@@ -232,7 +195,26 @@ local function setup(config)
   end
 end
 
+---@param buffer integer
+local function update_git_status(buffer)
+  load_git_status(buffer, function(status)
+    current_status = status
+    add_status_extmarks(buffer, current_status)
+  end)
+end
+
+---@param buffer integer
+local function refresh(buffer)
+  if current_status then
+    add_status_extmarks(buffer, current_status)
+  end
+end
+
 return {
   setup = setup,
   highlight_groups = highlight_groups,
+  validate_oil_config = validate_oil_config,
+  set_highlights = set_highlights,
+  update_git_status = update_git_status,
+  refresh = refresh,
 }

--- a/lua/oil-git-status.lua
+++ b/lua/oil-git-status.lua
@@ -5,7 +5,7 @@ local default_config = {
   show_ignored = true,
 }
 
-local current_config = vim.tbl_extend("force", default_config, {})
+local current_config = vim.tbl_extend("force", default_config, vim.g.oil_git_status or {})
 
 local function set_filename_status_code(filename, index_status_code, working_status_code, status)
   local dir_index = filename:find("/")

--- a/lua/oil-git-status.lua
+++ b/lua/oil-git-status.lua
@@ -148,10 +148,15 @@ local function load_git_status(buffer, callback)
   end)
 end
 
-local function validate_oil_config()
+---@return boolean
+local function is_valid_oil_config()
   local oil_config = require("oil.config")
-  local signcolumn = oil_config.win_options.signcolumn
-  if not (vim.startswith(signcolumn, "yes") or vim.startswith(signcolumn, "auto")) then
+  local signcolumn = oil_config.win_options and oil_config.win_options.signcolumn
+  return signcolumn ~= nil and vim.startswith(signcolumn, "yes") or vim.startswith(signcolumn, "auto")
+end
+
+local function validate_oil_config()
+  if not is_valid_oil_config() then
     vim.notify(
       "oil-git-status requires win_options.signcolumn to be set to at least 'yes:2' or 'auto:2'",
       vim.log.levels.WARN,
@@ -213,6 +218,7 @@ end
 return {
   setup = setup,
   highlight_groups = highlight_groups,
+  is_valid_oil_config = is_valid_oil_config,
   validate_oil_config = validate_oil_config,
   set_highlights = set_highlights,
   update_git_status = update_git_status,

--- a/lua/oil-git-status/health.lua
+++ b/lua/oil-git-status/health.lua
@@ -1,0 +1,23 @@
+local oil_git_status = require("oil-git-status")
+
+local h = vim.health
+
+local function check()
+  h.start("Checking if oil.nvim is installed")
+  local is_oil_installed = pcall(require, "oil")
+  if is_oil_installed then
+    h.ok("oil.nvim is installed")
+    h.start("Checking oil.nvim config")
+    if oil_git_status.is_valid_oil_config() then
+      h.ok("oil.nvim is configured correctly")
+    else
+      h.error("oil-git-status requires win_options.signcolumn to be set to at least 'yes:2' or 'auto:2'")
+    end
+  else
+    h.error("oil.nvim is not installed")
+  end
+end
+
+return {
+  check = check,
+}


### PR DESCRIPTION
Hey :wave: 

Nice plugin!

I would love to use it, but the need to call a `setup` function to enable this plugin's functionality has some caveats:

- It forces users to either use lazy.nvim, or implement lazy loading manually, or always run the `setup` function, even without using oil.nvim.
- Users have to ensure that oil.nvim is configured before this plugin.
- See also [rocks.nvim#should-i-lazy-load-plugins](https://github.com/nvim-neorocks/rocks.nvim?tab=readme-ov-file#should-i-lazy-load-plugins).

This PR uses Neovim's built-in `ftplugin` feature (see `:h runtimepath`) to make sure this plugin initialises itself lazily, when opening a `oil` filetype.
As a nice side-effect, this also means that users (or plugin managers) don't have to worry about the order in which oil.nvim and this plugin are configured (oil.nvim must be loaded in order for Neovim to know about the `oil` filetype).
The `setup` function only sets the config, but doesn't load anything.

- I've also added a small health check.

- And, since `setup` now only overrides the default configuration, I have added support for configuring this plugin with a `vim.g.oil_git_status` table.
  This has two benefits over a `setup` function:
  1. If the plugin is not installed or loaded, Neovim won't error on a `require` call (allowing users to disable the plugin without deleting the config).
  2. It allows configuration from vimscript: `g:oil_git_status = { "show_ignored": 1 }`