### PR TITLE
fix: (Windows) file_url is not a valid URL to pass into uri_to_fname

### DIFF
--- a/lua/oil-git-status.lua
+++ b/lua/oil-git-status.lua
@@ -123,6 +123,7 @@ end
 local function load_git_status(buffer, callback)
   local oil_url = vim.api.nvim_buf_get_name(buffer)
   local file_url = oil_url:gsub("^oil", "file")
+  if vim.fn.has "win32" == 1 then file_url = file_url:gsub("file:///([A-Za-z])/", "file:///%1:/") end
   local path = vim.uri_to_fname(file_url)
   concurrent({
     function(cb)


### PR DESCRIPTION
The Oil URL is no valid file URL in Windows. It misses the colon after the drive letter.

My addition checks if we are on a windows system and appends the colon to the drive letter. The URL is passed successfully and the plugin works correctly on windows now. 

Should fix #10 