### PR TITLE
fix: do not try use non-existent directory

### DIFF
--- a/lua/oil-git-status.lua
+++ b/lua/oil-git-status.lua
@@ -145,6 +145,7 @@ local function load_git_status(buffer, callback)
     file_url = file_url:gsub("file:///([A-Za-z])/", "file:///%1:/")
   end
   local path = vim.uri_to_fname(file_url)
+  if vim.fn.isdirectory(path) == 0 then return end
   concurrent({
     function(cb)
       -- quotepath=false - don't escape UTF-8 paths.


### PR DESCRIPTION
This is a potential fix for #18 

If the `path` returned by `uri_to_fname` is not a directory, don't try to add status in this directory.
