### PR TITLE
Fix for issue #18, elliminates problems with 'oil-ssh' and 'oil-trash' buffers.

### DIFF
--- a/lua/oil-git-status.lua
+++ b/lua/oil-git-status.lua
@@ -140,9 +140,6 @@ end
 
 local function load_git_status(buffer, callback)
   local oil_url = vim.api.nvim_buf_get_name(buffer)
-  if not oil_url:match("^oil:%a*") then
-      return
-  end
   local file_url = oil_url:gsub("^oil", "file")
   if vim.fn.has("win32") == 1 then
     file_url = file_url:gsub("file:///([A-Za-z])/", "file:///%1:/")
@@ -227,6 +224,12 @@ local function setup(config)
     callback = function()
       local buffer = vim.api.nvim_get_current_buf()
       local current_status = nil
+
+      -- Ignore ssh and trash buffers
+      local oil_url = vim.api.nvim_buf_get_name(buffer)
+      if nil == oil_url:find("^oil:") then
+          return
+      end
 
       if vim.b[buffer].oil_git_status_started then
         return


### PR DESCRIPTION
Filter out buffers by filename before installing event hooks, effectively ignoring all except these starting with "oil:"
[issue#18](https://github.com/refractalize/oil-git-status.nvim/issues/18) 

@caoculus 